### PR TITLE
fix: preview container height in docs shell

### DIFF
--- a/src/components/docs-focus/docs-focus-shell.tsx
+++ b/src/components/docs-focus/docs-focus-shell.tsx
@@ -1063,7 +1063,7 @@ function ComponentPage({
         >
           <div
             data-component-preview
-            className="flex min-h-0 w-full items-center justify-center"
+            className="flex min-h-0 w-full items-center justify-center h-full"
           >
             {preview}
           </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the component preview area to fill the full height of its parent container, improving layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->