### PR TITLE
fix: Implement editorial changelog layout and GitHub link

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -354,7 +354,7 @@ html {
     --docs-heading-scroll-offset: 5rem;
     --docs-h1-space-before: 0.5rem;
     --docs-h1-space-after: 0.5rem;
-    --docs-h2-space-before: 2.5rem;
+    --docs-h2-space-before: 1rem;
     --docs-h2-space-after: 0.75rem;
     --docs-h3-space-before: 1.75rem;
     --docs-h3-space-after: 0.5rem;
@@ -585,6 +585,153 @@ html {
 
     & .docs-list-item {
         line-height: 1.6;
+    }
+}
+
+/* Generated release notes, presented as an editorial timeline. */
+[data-context="component-article"].docs-changelog-prose {
+    --changelog-rail: color-mix(in oklch, var(--foreground) 14%, transparent);
+    --changelog-dot: color-mix(in oklch, var(--foreground) 78%, transparent);
+
+    padding-block-end: 1rem;
+
+    &::before {
+        position: absolute;
+        inset-block: 7.4rem 1.5rem;
+        inset-inline-start: 0.4375rem;
+        width: 1px;
+        background: linear-gradient(
+            to bottom,
+            transparent,
+            var(--changelog-rail) 2rem,
+            var(--changelog-rail) calc(100% - 2rem),
+            transparent
+        );
+        content: "";
+    }
+
+    & > .docs-paragraph:first-of-type {
+        max-inline-size: 48ch;
+        margin-block-end: 3.25rem;
+    }
+
+    & .changelog-release {
+        position: relative;
+        display: flex;
+        align-items: baseline;
+        gap: 0.75rem;
+        margin-block: 0 1.25rem;
+        padding-inline-start: 2rem;
+        font-size: clamp(1.125rem, 1.05rem + 0.35vw, 1.3rem);
+        font-weight: 600;
+        line-height: 1.2;
+        letter-spacing: -0.015em;
+    }
+
+    & .changelog-release:not(:first-of-type) {
+        margin-block-start: 2.5rem;
+    }
+
+    & .changelog-release::before {
+        position: absolute;
+        inset-block-start: 0.28em;
+        inset-inline-start: 0;
+        width: 0.875rem;
+        height: 0.875rem;
+        border: 3px solid var(--card);
+        border-radius: 999px;
+        background: var(--changelog-dot);
+        box-shadow: 0 0 0 1px var(--changelog-rail);
+        content: "";
+    }
+
+    & .changelog-release-version .docs-link {
+        text-decoration: none;
+    }
+
+    & .changelog-release-date {
+        color: var(--docs-subtle-foreground);
+        font-family: var(--font-geist-mono), monospace;
+        font-size: 0.7rem;
+        font-weight: 400;
+        letter-spacing: 0;
+        white-space: nowrap;
+    }
+
+    & .docs-heading-h3 {
+        margin-block: 1.75rem 0.625rem;
+        margin-inline-start: 2rem;
+        color: var(--docs-subtle-foreground);
+        font-size: 0.6875rem;
+        font-weight: 600;
+        line-height: 1.4;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    & .docs-list {
+        margin-block: 0;
+        margin-inline-start: 2rem;
+        gap: 0.625rem;
+        list-style: none;
+    }
+
+    & .docs-list-item {
+        position: relative;
+        padding-inline-start: 1rem;
+        color: color-mix(
+            in oklch,
+            var(--foreground) 84%,
+            var(--muted-foreground)
+        );
+        line-height: 1.55;
+    }
+
+    & .docs-list-item::before {
+        position: absolute;
+        inset-block-start: 0.66em;
+        inset-inline-start: 0;
+        width: 0.25rem;
+        height: 0.25rem;
+        border-radius: 999px;
+        background: var(--changelog-rail);
+        content: "";
+    }
+
+    & .docs-list-item .docs-link {
+        color: var(--docs-subtle-foreground);
+        font-family: var(--font-geist-mono), monospace;
+        font-size: 0.72em;
+        text-decoration-color: transparent;
+    }
+
+    & .docs-list + .docs-paragraph {
+        margin-block: 1.25rem 0;
+        margin-inline-start: 2rem;
+        font-size: 0.8125rem;
+    }
+
+    & .docs-list + .docs-paragraph .docs-link {
+        font-weight: 500;
+        text-decoration: none;
+    }
+
+    & .docs-divider {
+        block-size: 2.5rem;
+    }
+
+    & > hr {
+        display: none;
+    }
+}
+
+@media (max-width: 40rem) {
+    [data-context="component-article"].docs-changelog-prose {
+        & .changelog-release {
+            align-items: flex-start;
+            flex-direction: column;
+            gap: 0.375rem;
+        }
     }
 }
 

--- a/src/components/common/mdx-components.tsx
+++ b/src/components/common/mdx-components.tsx
@@ -1,6 +1,7 @@
 import { useMDXComponent } from "@content-collections/mdx/react";
 import Image from "next/image";
 import Link from "next/link";
+import { Children } from "react";
 import {
   CodeBlock,
   CodeBlockCode,
@@ -34,6 +35,69 @@ function getHeadingId(children: React.ReactNode) {
     .replace(/[^a-z0-9\s-]/g, "")
     .trim()
     .replace(/\s+/g, "-");
+}
+
+function ChangelogReleaseHeading({
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLHeadingElement>) {
+  const releaseDate = Children.toArray(children)
+    .filter((child): child is string => typeof child === "string")
+    .map((child) => child.match(/\((\d{4}-\d{2}-\d{2})\)/)?.[1])
+    .find(Boolean);
+
+  return (
+    <h2
+      data-doc-heading
+      className={cn(
+        "docs-heading docs-heading-h2 changelog-release",
+        className,
+      )}
+      {...props}
+    >
+      <span className="changelog-release-version">
+        {Children.map(children, (child) =>
+          typeof child === "string"
+            ? child.replace(/\s*\(\d{4}-\d{2}-\d{2}\)/, "")
+            : child,
+        )}
+      </span>
+      {releaseDate && (
+        <time className="changelog-release-date" dateTime={releaseDate}>
+          {releaseDate}
+        </time>
+      )}
+    </h2>
+  );
+}
+
+function ChangelogHeading({
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLHeadingElement>) {
+  const isRelease = Children.toArray(children).some(
+    (child) => typeof child === "string" && /\(\d{4}-\d{2}-\d{2}\)/.test(child),
+  );
+
+  if (isRelease) {
+    return (
+      <ChangelogReleaseHeading className={className} {...props}>
+        {children}
+      </ChangelogReleaseHeading>
+    );
+  }
+
+  return (
+    <h1
+      data-doc-heading
+      className={cn("docs-heading docs-heading-h1", className)}
+      {...props}
+    >
+      {children}
+    </h1>
+  );
 }
 
 const CustomLink = (props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
@@ -141,7 +205,7 @@ const components = {
   }: React.BlockquoteHTMLAttributes<HTMLQuoteElement>) => (
     <blockquote className={cn("docs-blockquote", className)} {...props} />
   ),
-  Divider: () => <div className="docs-divider" />,
+  Divider: () => <div className="docs-divider h-0!" />,
   CodeSyntaxHighlighter,
   ComponentWrapper,
   Tabs,
@@ -181,8 +245,12 @@ export function Mdx({
   sourceFiles,
 }: MDXProps) {
   const Component = useMDXComponent(code);
+  const isChangelog = className?.includes("docs-changelog-prose");
   const mdxComponents = {
     ...components,
+    ...(isChangelog
+      ? { h1: ChangelogHeading, h2: ChangelogReleaseHeading }
+      : {}),
     SourceCode: ({
       source,
       filename,
@@ -205,22 +273,49 @@ export function Mdx({
       ? {
           h1: ({
             className: headingClassName,
-            ...props
-          }: React.HTMLAttributes<HTMLHeadingElement>) => (
-            <>
-              <h1
-                data-doc-heading
-                className={cn("docs-heading docs-heading-h1", headingClassName)}
-                {...props}
-              />
-              <div className="flex flex-col gap-4 md:pt-4 mobile:mb-2 lg:absolute lg:top-0 lg:right-0 lg:block lg:pt-0">
-                {headerActions}
-                {mobileHeaderContent && (
-                  <div className="lg:hidden">{mobileHeaderContent}</div>
-                )}
-              </div>
-            </>
-          ),
+            children,
+            ...headingProps
+          }: React.HTMLAttributes<HTMLHeadingElement>) => {
+            const isRelease =
+              isChangelog &&
+              Children.toArray(children).some(
+                (child) =>
+                  typeof child === "string" &&
+                  /\(\d{4}-\d{2}-\d{2}\)/.test(child),
+              );
+
+            if (isRelease) {
+              return (
+                <ChangelogReleaseHeading
+                  className={headingClassName}
+                  {...headingProps}
+                >
+                  {children}
+                </ChangelogReleaseHeading>
+              );
+            }
+
+            return (
+              <>
+                <h1
+                  data-doc-heading
+                  className={cn(
+                    "docs-heading docs-heading-h1",
+                    headingClassName,
+                  )}
+                  {...headingProps}
+                >
+                  {children}
+                </h1>
+                <div className="flex flex-col gap-4 md:pt-4 mobile:mb-2 lg:absolute lg:top-0 lg:right-0 lg:block lg:pt-0">
+                  {headerActions}
+                  {mobileHeaderContent && (
+                    <div className="lg:hidden">{mobileHeaderContent}</div>
+                  )}
+                </div>
+              </>
+            );
+          },
         }
       : {}),
   };

--- a/src/components/common/start-count.tsx
+++ b/src/components/common/start-count.tsx
@@ -16,13 +16,12 @@ const StartCount = () => {
   }, [stars]);
 
   return (
-    <span className="flex relative items-center justify-center space-x-1.5 hover:outline-b group">
+    <span className="flex relative items-center justify-center space-x-1.5 group">
       <FaGithub />
       <span className="hidden lg:block leading-3.5 sr-only">
         Star on GitHub
       </span>
       <NumberFlow value={starCount} />
-      <div className="absolute left-0 h-0.5 w-0 group-hover:w-full bg-foreground duration-300 transition-[width] -bottom-0.5"></div>
     </span>
   );
 };

--- a/src/components/docs-focus/docs-focus-shell.tsx
+++ b/src/components/docs-focus/docs-focus-shell.tsx
@@ -14,6 +14,7 @@ import { motion, useReducedMotion } from "motion/react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { type ReactNode, useEffect, useId, useMemo, useState } from "react";
+import { FaGithub } from "react-icons/fa";
 import {
   Drawer,
   DrawerContent,
@@ -40,6 +41,7 @@ import { YarnIcon } from "@/components/svgs/yarn-logo";
 import { groupedComponents } from "@/config/components";
 import { SITE_METADATA } from "@/config/site";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { GIT_REP_LINK } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 import { exampleRegistry } from "@/registry/index";
 import { type Control, playgroundRegistry } from "@/registry/playground";
@@ -501,7 +503,10 @@ function GuidePage({
             <div className="mx-auto max-w-[82ch]">
               <Mdx
                 code={doc.body.code}
-                className="docs-guide-prose"
+                className={cn(
+                  "docs-guide-prose",
+                  doc.slug === "changelog" && "docs-changelog-prose",
+                )}
                 headerActions={copyActions}
                 sourceFiles={doc.sourceFiles}
               />
@@ -983,6 +988,17 @@ function ComponentPage({
           </FocusActionTooltip>
           <FocusActionTooltip id="focus-search" label="Search">
             <Search compact />
+          </FocusActionTooltip>
+          <FocusActionTooltip id="focus-github" label="View on GitHub">
+            <a
+              href={GIT_REP_LINK}
+              target="_blank"
+              rel="noreferrer"
+              aria-label="View Sona UI on GitHub"
+              className="grid size-9 place-items-center rounded-lg text-muted-foreground transition-colors duration-150 ease-out hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <FaGithub className="size-4" aria-hidden="true" />
+            </a>
           </FocusActionTooltip>
           <FocusActionTooltip id="focus-description" label="Description">
             <IconButton

--- a/src/content/docs/changelog.mdx
+++ b/src/content/docs/changelog.mdx
@@ -11,6 +11,52 @@ Stay up to date with the latest changes in Sona UI.
 
 
 
+## [2.19.3](https://github.com/Dinil-Thilakarathne/sona-ui/compare/v2.19.2...v2.19.3) (2026-08-30)
+
+
+### Bug Fixes
+
+* preview container height in docs shell ([a1edf1f](https://github.com/Dinil-Thilakarathne/sona-ui/commit/a1edf1f790dd507a21a90d667a5b58cad1ca78a0))
+
+
+[View on GitHub](https://github.com/Dinil-Thilakarathne/sona-ui/releases/tag/v2.19.3)
+<Divider/>
+
+---
+
+
+
+## [2.19.2](https://github.com/Dinil-Thilakarathne/sona-ui/compare/v2.19.1...v2.19.2) (2026-08-30)
+
+
+### Bug Fixes
+
+* Update CTA link to point to components page ([46d9985](https://github.com/Dinil-Thilakarathne/sona-ui/commit/46d9985ea5233b9bd299fa9fa3bade7776878f3a))
+
+
+[View on GitHub](https://github.com/Dinil-Thilakarathne/sona-ui/releases/tag/v2.19.2)
+<Divider/>
+
+---
+
+
+
+## [2.19.1](https://github.com/Dinil-Thilakarathne/sona-ui/compare/v2.19.0...v2.19.1) (2026-08-30)
+
+
+### Bug Fixes
+
+* Update header navigation padding and changelog ([045bae7](https://github.com/Dinil-Thilakarathne/sona-ui/commit/045bae70b12248125278dbd8e5530909cc9d4829))
+* Update hero button link to components page ([3c7ab63](https://github.com/Dinil-Thilakarathne/sona-ui/commit/3c7ab633ee35d32644eb5151ad5414d07532a265))
+
+
+[View on GitHub](https://github.com/Dinil-Thilakarathne/sona-ui/releases/tag/v2.19.1)
+<Divider/>
+
+---
+
+
+
 # [2.19.0](https://github.com/Dinil-Thilakarathne/sona-ui/compare/v2.18.0...v2.19.0) (2026-08-30)
 
 
@@ -767,68 +813,4 @@ Stay up to date with the latest changes in Sona UI.
 
 
 [View on GitHub](https://github.com/Dinil-Thilakarathne/sona-ui/releases/tag/v2.1.0)
-<Divider/>
-
----
-
-
-
-## [2.0.2](https://github.com/Dinil-Thilakarathne/sona-ui/compare/v2.0.1...v2.0.2) (2025-05-11)
-
-
-### Bug Fixes
-
-*  clean up transition properties ([988284f](https://github.com/Dinil-Thilakarathne/sona-ui/commit/988284fc7dfad5a0884cecd65f104a95eb0ceee8))
-
-
-
-
-
-[View on GitHub](https://github.com/Dinil-Thilakarathne/sona-ui/releases/tag/v2.0.2)
-<Divider/>
-
----
-
-
-
-## [2.0.1](https://github.com/Dinil-Thilakarathne/sona-ui/compare/v2.0.0...v2.0.1) (2025-05-10)
-
-
-### Bug Fixes
-
-* update button link to point to the correct documentation home page ([3198621](https://github.com/Dinil-Thilakarathne/sona-ui/commit/31986210882286d02ad4cb10c77f00d9aa5905e5))
-
-
-
-
-
-[View on GitHub](https://github.com/Dinil-Thilakarathne/sona-ui/releases/tag/v2.0.1)
-<Divider/>
-
----
-
-
-
-# [2.0.0](https://github.com/Dinil-Thilakarathne/sona-ui/compare/v1.3.0...v2.0.0) (2025-05-10)
-
-
-* feat!: new version released ([20cb49d](https://github.com/Dinil-Thilakarathne/sona-ui/commit/20cb49d2fa784dd480a972ceb4d0661a754fba14))
-
-
-### Features
-
-* add manifest.json for PWA support ([f80cdd9](https://github.com/Dinil-Thilakarathne/sona-ui/commit/f80cdd922fdc88c6451962e70e031d02719a2dd4))
-* add robots.txt generation for SEO optimization ([0714dd2](https://github.com/Dinil-Thilakarathne/sona-ui/commit/0714dd2fc5f7a8c908d313db7b9fd00ecac201b4))
-* add sitemap generation for improved SEO ([830db1f](https://github.com/Dinil-Thilakarathne/sona-ui/commit/830db1fd7681ac1f591f26a7323728933f08daa7))
-
-
-### BREAKING CHANGES
-
-* new version released
-
-
-
-
-
-[View on GitHub](https://github.com/Dinil-Thilakarathne/sona-ui/releases/tag/v2.0.0)
 <Divider/>


### PR DESCRIPTION
- Added `docs-changelog-prose` styles for a timeline-based view.
- Created `ChangelogHeading` and `ChangelogReleaseHeading` MDX components to parse and format release versions and dates.
- Integrated GitHub link into the focus shell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added changelog entries for versions 2.19.3, 2.19.2, and 2.19.1, including release dates, bug-fix notes, and links to GitHub.
  - Added a “View on GitHub” action to documentation pages.
  - Introduced a responsive timeline layout for changelog releases.

- **Style**
  - Improved changelog headings, dates, lists, links, spacing, and mobile presentation.
  - Simplified the star-count display by removing hover and border animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->